### PR TITLE
remove wrong type hint

### DIFF
--- a/src/clojure/clojurewerkz/scrypt/core.clj
+++ b/src/clojure/clojurewerkz/scrypt/core.clj
@@ -33,7 +33,7 @@
   [^String s ^long n ^long r ^long p]
   (SCryptUtil/scrypt s n r p))
 
-(defn ^boolean verify
+(defn verify
   "Verifies a value against a hash produced by scrypt"
   [^String candidate ^String hash]
   (SCryptUtil/check candidate hash))


### PR DESCRIPTION
Attaching a primitive type hint to a def name results in the corresponding clojure.core function to be attached, instead of the right hint

user=> (def ^boolean a true)
# 'user/a

user=> (:tag (meta #'a))
# <core$boolean clojure.core$boolean@2f860a43>

It is explicitely stated in http://clojure.org/special_forms#Special%20Forms--(def%20symbol%20init?) that the metadata will be evaluated so even though counterintuitive, this is not a clojure bug.

Also, clojure only allows for double and long primitive hints so the hint was useless.
