### PR TITLE
Fixing the docstring for core/encrypt.

### DIFF
--- a/src/clojure/clojurewerkz/scrypt/core.clj
+++ b/src/clojure/clojurewerkz/scrypt/core.clj
@@ -29,7 +29,7 @@
    Arguments are:
 
    s (string): a string to encrypt
-   n (integer): CPU cost parameter (16834 is a good starting value)
+   n (integer): CPU cost parameter (16384 is a good starting value)
    r (integer): RAM cost parameter (8 is a good starting value)
    p (integer): parallelism parameter (1 is a good starting value)"
   [^String s ^long n ^long r ^long p]


### PR DESCRIPTION
It's incorrectly advising 16834 as a good CPU cost parameter, but using
that value throws:

IllegalArgumentException N must be a power of 2 greater than 1
com.lambdaworks.crypto.SCrypt.scryptN (SCrypt.java:-2)

The value should be 16384. The 3 & 8 had been transposed.
